### PR TITLE
Feat: Implement CV and Logo upload functionality

### DIFF
--- a/src/Services/ProfileService/Profile.API/Controllers/CandidateProfileController.cs
+++ b/src/Services/ProfileService/Profile.API/Controllers/CandidateProfileController.cs
@@ -4,6 +4,7 @@ using Profile.API.DTOs;
 using Profile.API.Features.CandidateProfiles.Commands.CreateCandidate;
 using Profile.API.Features.CandidateProfiles.Commands.DeleteCandidate;
 using Profile.API.Features.CandidateProfiles.Commands.UpdateCandidate;
+using Profile.API.Features.CandidateProfiles.Commands.UploadCv;
 using Profile.API.Features.CandidateProfiles.Queries.GetCandidateProfile;
 
 namespace Profile.API.Controllers
@@ -30,6 +31,17 @@ namespace Profile.API.Controllers
             logger.LogInformation("Received CreateCandidateProfile request for userId: {UserId}", command.UserId);
             var id = await mediator.Send(command);
             return CreatedAtAction(nameof(GetCandidateProfile), new { userId = command.UserId }, id);
+        }
+
+        [HttpPost("{id}/cv")]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UploadCv(Guid id, IFormFile file)
+        {
+            logger.LogInformation("Received CV upload request for candidate Id: {Id}", id);
+            var url = await mediator.Send(new UploadCandidateCvCommand { Id = id, File = file });
+            return url != null ? Ok(new { CvUrl = url }) : NotFound();
         }
 
         [HttpPut("{id}")]

--- a/src/Services/ProfileService/Profile.API/Controllers/CompanyProfileController.cs
+++ b/src/Services/ProfileService/Profile.API/Controllers/CompanyProfileController.cs
@@ -4,6 +4,7 @@ using Profile.API.DTOs;
 using Profile.API.Features.CompanyProfiles.Commands.CreateCompany;
 using Profile.API.Features.CompanyProfiles.Commands.DeleteCompany;
 using Profile.API.Features.CompanyProfiles.Commands.UpdateCompany;
+using Profile.API.Features.CompanyProfiles.Commands.UploadLogo;
 using Profile.API.Features.CompanyProfiles.Queries.GetCompanyProfile;
 
 namespace Profile.API.Controllers
@@ -30,6 +31,17 @@ namespace Profile.API.Controllers
             logger.LogInformation("Received CreateCompanyProfile request for userId: {UserId}", command.UserId);
             var id = await mediator.Send(command);
             return CreatedAtAction(nameof(GetCompanyProfile), new { userId = command.UserId }, id);
+        }
+
+        [HttpPost("{id}/logo")]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UploadLogo(Guid id, IFormFile file)
+        {
+            logger.LogInformation("Received Logo upload request for company Id: {Id}", id);
+            var url = await mediator.Send(new UploadCompanyLogoCommand { Id = id, File = file });
+            return url != null ? Ok(new { Logo = url }) : NotFound();
         }
 
         [HttpPut("{id}")]

--- a/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/UploadCv/UploadCandidateCvCommand.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/UploadCv/UploadCandidateCvCommand.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+
+namespace Profile.API.Features.CandidateProfiles.Commands.UploadCv
+{
+    public class UploadCandidateCvCommand : IRequest<string?>
+    {
+        public Guid Id { get; set; }
+        public IFormFile File { get; set; } = null!;
+    }
+}

--- a/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/UploadCv/UploadCandidateCvCommandHandler.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/UploadCv/UploadCandidateCvCommandHandler.cs
@@ -1,0 +1,41 @@
+﻿using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Profile.API.Data;
+
+namespace Profile.API.Features.CandidateProfiles.Commands.UploadCv
+{
+    public class UploadCandidateCvCommandHandler(IProfileContext context, IWebHostEnvironment environment, ILogger<UploadCandidateCvCommandHandler> logger) : IRequestHandler<UploadCandidateCvCommand, string?>
+    {
+        public async Task<string?> Handle(UploadCandidateCvCommand request, CancellationToken cancellationToken)
+        {
+            var profile = await context.CandidateProfiles.FirstOrDefaultAsync(p => p.Id == request.Id, cancellationToken);
+
+            if (profile == null)
+            {
+                logger.LogWarning("Candidate profile {Id} not found.", request.Id);
+                return null;
+            }
+
+            var rootPath = environment.WebRootPath ?? Path.Combine(Directory.GetCurrentDirectory(), "wwwroot");
+            var cvsFolder = Path.Combine(rootPath, "uploads", "cvs");
+            Directory.CreateDirectory(cvsFolder);
+
+            var fileName = $"{Guid.NewGuid()}_{Path.GetFileName(request.File.FileName)}";
+            var filePath = Path.Combine(cvsFolder, fileName);
+
+            using (var fileStream = new FileStream(filePath, FileMode.Create))
+            {
+                await request.File.CopyToAsync(fileStream, cancellationToken);
+            }
+
+            var fileUrl = $"/uploads/cvs/{fileName}";
+            profile.CvUrl = fileUrl;
+            profile.ModifiedAt = DateTime.UtcNow;
+
+            await context.SaveChangesAsync(cancellationToken);
+            logger.LogInformation("Saved CV for candidate {Id} at path {Path}", profile.Id, fileUrl);
+
+            return fileUrl;
+        }
+    }
+}

--- a/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/Validators/UploadCandidateCvCommandValidator.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/Validators/UploadCandidateCvCommandValidator.cs
@@ -1,0 +1,19 @@
+﻿using FluentValidation;
+using Profile.API.Features.CandidateProfiles.Commands.UploadCv;
+
+namespace Profile.API.Features.CandidateProfiles.Commands.Validators
+{
+    public class UploadCandidateCvCommandValidator : AbstractValidator<UploadCandidateCvCommand>
+    {
+        public UploadCandidateCvCommandValidator()
+        {
+            RuleFor(p => p.Id).NotEmpty().WithMessage("Id is required.");
+
+            RuleFor(p => p.File)
+                .Cascade(CascadeMode.Stop)
+                .NotNull().WithMessage("File is required.")
+                .Must(f => f.Length <= 5 * 1024 * 1024).WithMessage("File size must be less than 5MB.")
+                .Must(f => f.ContentType == "application/pdf").WithMessage("Only PDF files are allowed for CV upload.");
+        }
+    }
+}

--- a/src/Services/ProfileService/Profile.API/Features/CompanyProfiles/Commands/UploadLogo/UploadCompanyLogoCommand.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CompanyProfiles/Commands/UploadLogo/UploadCompanyLogoCommand.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+
+namespace Profile.API.Features.CompanyProfiles.Commands.UploadLogo
+{
+    public class UploadCompanyLogoCommand : IRequest<string?>
+    {
+        public Guid Id { get; set; }
+        public IFormFile File { get; set; } = null!;
+    }
+}

--- a/src/Services/ProfileService/Profile.API/Features/CompanyProfiles/Commands/UploadLogo/UploadCompanyLogoCommandHandler.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CompanyProfiles/Commands/UploadLogo/UploadCompanyLogoCommandHandler.cs
@@ -1,0 +1,41 @@
+﻿using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Profile.API.Data;
+
+namespace Profile.API.Features.CompanyProfiles.Commands.UploadLogo
+{
+    public class UploadCompanyLogoCommandHandler(IProfileContext context, IWebHostEnvironment environment, ILogger<UploadCompanyLogoCommandHandler> logger) : IRequestHandler<UploadCompanyLogoCommand, string?>
+    {
+        public async Task<string?> Handle(UploadCompanyLogoCommand request, CancellationToken cancellationToken)
+        {
+            var profile = await context.CompanyProfiles.FirstOrDefaultAsync(p => p.Id == request.Id, cancellationToken);
+
+            if (profile == null)
+            {
+                logger.LogWarning("Company profile {Id} not found.", request.Id);
+                return null;
+            }
+
+            var rootPath = environment.WebRootPath ?? Path.Combine(Directory.GetCurrentDirectory(), "wwwroot");
+            var logosFolder = Path.Combine(rootPath, "uploads", "logos");
+            Directory.CreateDirectory(logosFolder);
+
+            var fileName = $"{Guid.NewGuid()}_{Path.GetFileName(request.File.FileName)}";
+            var filePath = Path.Combine(logosFolder, fileName);
+
+            using (var fileStream = new FileStream(filePath, FileMode.Create))
+            {
+                await request.File.CopyToAsync(fileStream, cancellationToken);
+            }
+
+            var fileUrl = $"/uploads/logos/{fileName}";
+            profile.LogoUrl = fileUrl;
+            profile.ModifiedAt = DateTime.UtcNow;
+
+            await context.SaveChangesAsync(cancellationToken);
+            logger.LogInformation("Saved Logo for company {Id} at path {Path}", profile.Id, fileUrl);
+
+            return fileUrl;
+        }
+    }
+}

--- a/src/Services/ProfileService/Profile.API/Features/CompanyProfiles/Commands/Validators/UploadCompanyLogoCommandValidator.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CompanyProfiles/Commands/Validators/UploadCompanyLogoCommandValidator.cs
@@ -1,0 +1,20 @@
+﻿using FluentValidation;
+using Profile.API.Features.CompanyProfiles.Commands.UploadLogo;
+
+namespace Profile.API.Features.CompanyProfiles.Commands.Validators
+{
+    public class UploadCompanyLogoCommandValidator : AbstractValidator<UploadCompanyLogoCommand>
+    {
+        public UploadCompanyLogoCommandValidator()
+        {
+            RuleFor(p => p.Id).NotEmpty().WithMessage("Id is required.");
+
+            RuleFor(p => p.File)
+                .Cascade(CascadeMode.Stop)
+                .NotNull().WithMessage("File is required.")
+                .Must(f => f.Length <= 5 * 1024 * 1024).WithMessage("File size must be less than 5MB.")
+                .Must(f => f.ContentType == "image/png" || f.ContentType == "image/jpg" || f.ContentType == "image/jpeg")
+                    .WithMessage("Only png/jpg/jpeg files are allowed for Logo upload.");
+        }
+    }
+}

--- a/src/Services/ProfileService/Profile.API/Program.cs
+++ b/src/Services/ProfileService/Profile.API/Program.cs
@@ -42,6 +42,8 @@ if (app.Environment.IsDevelopment())
     app.MapScalarApiReference();
 }
 
+app.UseStaticFiles();
+
 app.MapControllers();
 
 app.Run();


### PR DESCRIPTION
This PR implements file upload functionality for CVs and Logos in the `Profile.API` service.

### What was done:
- **CQRS Implementation**: Added MediatR commands (`UploadCandidateCvCommand` and `UploadCompanyLogoCommand`) and their handlers.
- **Enabled Static File Usage**
- **API Endpoints**: Added `POST {id}/cv` and `POST {id}/logo` endpoints in their respective controllers.
- **File Validation**: Extended `FluentValidation` with rules to enforce 5MB file size limits and restrict content types (**PDF** for CVs, **PNG/JPG/JPEG** for logos).

Closes #20