### PR TITLE
Refactor: `CandidateProfile` entity

### DIFF
--- a/src/Services/ProfileService/Profile.API/DTOs/CandidateProfileDto.cs
+++ b/src/Services/ProfileService/Profile.API/DTOs/CandidateProfileDto.cs
@@ -9,11 +9,11 @@ public class CandidateProfileDto
     public string Email { get; set; } = string.Empty;
     public string PhoneNumber { get; set; } = string.Empty;
     public string Location { get; set; } = string.Empty;
-    public string Education { get; set; } = string.Empty;
-    public string Experience { get; set; } = string.Empty;
-    public string Projects { get; set; } = string.Empty;
-    public string Skills { get; set; } = string.Empty;
-    public string Languages { get; set; } = string.Empty;
+    public List<EducationDto> Education { get; set; } = new();
+    public List<ExperienceDto> Experience { get; set; } = new();
+    public List<ProjectDto> Projects { get; set; } = new();
+    public List<string> Skills { get; set; } = new();
+    public List<LanguageDto> Languages { get; set; } = new();
     public string CvUrl { get; set; } = string.Empty;
     public string? PictureUrl { get; set; }
     public string? GithubUrl { get; set; }

--- a/src/Services/ProfileService/Profile.API/DTOs/EducationDto.cs
+++ b/src/Services/ProfileService/Profile.API/DTOs/EducationDto.cs
@@ -1,4 +1,4 @@
 ﻿namespace Profile.API.DTOs
 {
-    public record EducationDto(string InstitutionName, DateTime StartDate, DateTime EndDate, string Degree);
+    public record EducationDto(string InstitutionName, DateTime StartDate, DateTime? EndDate, string? Degree);
 }

--- a/src/Services/ProfileService/Profile.API/DTOs/EducationDto.cs
+++ b/src/Services/ProfileService/Profile.API/DTOs/EducationDto.cs
@@ -1,0 +1,4 @@
+﻿namespace Profile.API.DTOs
+{
+    public record EducationDto(string InstitutionName, DateTime StartDate, DateTime EndDate, string Degree);
+}

--- a/src/Services/ProfileService/Profile.API/DTOs/ExperienceDto.cs
+++ b/src/Services/ProfileService/Profile.API/DTOs/ExperienceDto.cs
@@ -1,0 +1,4 @@
+﻿namespace Profile.API.DTOs
+{
+    public record ExperienceDto(string CompanyName, string Position, DateTime StartDate, DateTime EndDate);
+}

--- a/src/Services/ProfileService/Profile.API/DTOs/ExperienceDto.cs
+++ b/src/Services/ProfileService/Profile.API/DTOs/ExperienceDto.cs
@@ -1,4 +1,4 @@
 ﻿namespace Profile.API.DTOs
 {
-    public record ExperienceDto(string CompanyName, string Position, DateTime StartDate, DateTime EndDate);
+    public record ExperienceDto(string CompanyName, string Position, DateTime StartDate, DateTime? EndDate);
 }

--- a/src/Services/ProfileService/Profile.API/DTOs/LanguageDto.cs
+++ b/src/Services/ProfileService/Profile.API/DTOs/LanguageDto.cs
@@ -1,0 +1,4 @@
+﻿namespace Profile.API.DTOs
+{
+    public record LanguageDto(string Name, string Level);
+}

--- a/src/Services/ProfileService/Profile.API/DTOs/LanguageDto.cs
+++ b/src/Services/ProfileService/Profile.API/DTOs/LanguageDto.cs
@@ -1,4 +1,4 @@
 ﻿namespace Profile.API.DTOs
 {
-    public record LanguageDto(string Name, string Level);
+    public record LanguageDto(string Name, string? Level);
 }

--- a/src/Services/ProfileService/Profile.API/DTOs/ProjectDto.cs
+++ b/src/Services/ProfileService/Profile.API/DTOs/ProjectDto.cs
@@ -1,0 +1,4 @@
+﻿namespace Profile.API.DTOs
+{
+    public record ProjectDto(string Name, string Description, string RepositoryLink);
+}

--- a/src/Services/ProfileService/Profile.API/DTOs/ProjectDto.cs
+++ b/src/Services/ProfileService/Profile.API/DTOs/ProjectDto.cs
@@ -1,4 +1,4 @@
 ﻿namespace Profile.API.DTOs
 {
-    public record ProjectDto(string Name, string Description, string RepositoryLink);
+    public record ProjectDto(string Name, string? Description, string? RepositoryUrl);
 }

--- a/src/Services/ProfileService/Profile.API/Data/ProfileContext.cs
+++ b/src/Services/ProfileService/Profile.API/Data/ProfileContext.cs
@@ -13,6 +13,10 @@ namespace Profile.API.Data
 
         public DbSet<CandidateProfile> CandidateProfiles { get; set; } = null!;
         public DbSet<CompanyProfile> CompanyProfiles { get; set; } = null!;
+        public DbSet<Education> Educations { get; set; } = null!;
+        public DbSet<Experience> Experiences { get; set; } = null!;
+        public DbSet<Project> Projects { get; set; } = null!;
+        public DbSet<Language> Languages { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -20,6 +24,30 @@ namespace Profile.API.Data
 
             modelBuilder.Entity<CandidateProfile>().HasIndex(p => p.UserId).IsUnique();
             modelBuilder.Entity<CompanyProfile>().HasIndex(p => p.UserId).IsUnique();
+
+            modelBuilder.Entity<CandidateProfile>()
+                .HasMany(c => c.Education)
+                .WithOne(e => e.CandidateProfile)
+                .HasForeignKey(e => e.CandidateProfileId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<CandidateProfile>()
+                .HasMany(c => c.Experience)
+                .WithOne(e => e.CandidateProfile)
+                .HasForeignKey(e => e.CandidateProfileId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<CandidateProfile>()
+                .HasMany(c => c.Projects)
+                .WithOne(p => p.CandidateProfile)
+                .HasForeignKey(p => p.CandidateProfileId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<CandidateProfile>()
+                .HasMany(c => c.Languages)
+                .WithOne(l => l.CandidateProfile)
+                .HasForeignKey(l => l.CandidateProfileId)
+                .OnDelete(DeleteBehavior.Cascade);
         }
 
         public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/src/Services/ProfileService/Profile.API/Data/ProfileContext.cs
+++ b/src/Services/ProfileService/Profile.API/Data/ProfileContext.cs
@@ -13,8 +13,8 @@ namespace Profile.API.Data
 
         public DbSet<CandidateProfile> CandidateProfiles { get; set; } = null!;
         public DbSet<CompanyProfile> CompanyProfiles { get; set; } = null!;
-        public DbSet<Education> Educations { get; set; } = null!;
-        public DbSet<Experience> Experiences { get; set; } = null!;
+        public DbSet<Education> Education { get; set; } = null!;
+        public DbSet<Experience> Experience { get; set; } = null!;
         public DbSet<Project> Projects { get; set; } = null!;
         public DbSet<Language> Languages { get; set; } = null!;
 

--- a/src/Services/ProfileService/Profile.API/Entities/CandidateProfile.cs
+++ b/src/Services/ProfileService/Profile.API/Entities/CandidateProfile.cs
@@ -9,11 +9,11 @@
         public string Email { get; set; } = string.Empty;
         public string PhoneNumber { get; set; } = string.Empty;
         public string Location { get; set; } = string.Empty;
-        public string Education { get; set; } = string.Empty;
-        public string Experience { get; set; } = string.Empty;
-        public string Projects { get; set; } = string.Empty;
-        public string Skills { get; set; } = string.Empty;
-        public string Languages { get; set; } = string.Empty;
+        public List<Education> Education { get; set; } = new();
+        public List<Experience> Experience { get; set; } = new();
+        public List<Project> Projects { get; set; } = new();
+        public List<string> Skills { get; set; } = new();
+        public List<Language> Languages { get; set; } = new();
         public string CvUrl { get; set; } = string.Empty;
         public string? PictureUrl { get; set; }
         public string? GithubUrl { get; set; }

--- a/src/Services/ProfileService/Profile.API/Entities/Education.cs
+++ b/src/Services/ProfileService/Profile.API/Entities/Education.cs
@@ -1,0 +1,14 @@
+﻿namespace Profile.API.Entities
+{
+    public class Education
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public string InstitutionName { get; set; } = string.Empty;
+        public DateTime StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+        public string Degree { get; set; } = string.Empty;
+
+        public Guid CandidateProfileId { get; set; }
+        public CandidateProfile? CandidateProfile { get; set; }
+    }
+}

--- a/src/Services/ProfileService/Profile.API/Entities/Experience.cs
+++ b/src/Services/ProfileService/Profile.API/Entities/Experience.cs
@@ -1,0 +1,14 @@
+﻿namespace Profile.API.Entities
+{
+    public class Experience
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public string CompanyName { get; set; } = string.Empty;
+        public string Position { get; set; } = string.Empty;
+        public DateTime StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+
+        public Guid CandidateProfileId { get; set; }
+        public CandidateProfile? CandidateProfile { get; set; }
+    }
+}

--- a/src/Services/ProfileService/Profile.API/Entities/Language.cs
+++ b/src/Services/ProfileService/Profile.API/Entities/Language.cs
@@ -1,0 +1,12 @@
+﻿namespace Profile.API.Entities
+{
+    public class Language
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public string Name { get; set; } = string.Empty;
+        public string? Level { get; set; } = string.Empty;
+
+        public Guid CandidateProfileId { get; set; }
+        public CandidateProfile? CandidateProfile { get; set; }
+    }
+}

--- a/src/Services/ProfileService/Profile.API/Entities/Project.cs
+++ b/src/Services/ProfileService/Profile.API/Entities/Project.cs
@@ -1,0 +1,13 @@
+﻿namespace Profile.API.Entities
+{
+    public class Project
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string? RepositoryLink { get; set; }
+
+        public Guid CandidateProfileId { get; set; }
+        public CandidateProfile? CandidateProfile { get; set; }
+    }
+}

--- a/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/CreateCandidate/CreateCandidateProfileCommand.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/CreateCandidate/CreateCandidateProfileCommand.cs
@@ -1,4 +1,5 @@
 ﻿using MediatR;
+using Profile.API.DTOs;
 
 namespace Profile.API.Features.CandidateProfiles.Commands.CreateCandidate
 {
@@ -10,11 +11,11 @@ namespace Profile.API.Features.CandidateProfiles.Commands.CreateCandidate
         public string Email { get; set; } = string.Empty;
         public string PhoneNumber { get; set; } = string.Empty;
         public string Location { get; set; } = string.Empty;
-        public string Education { get; set; } = string.Empty;
-        public string Experience { get; set; } = string.Empty;
-        public string Projects { get; set; } = string.Empty;
-        public string Skills { get; set; } = string.Empty;
-        public string Languages { get; set; } = string.Empty;
+        public List<EducationDto> Education { get; set; } = new();
+        public List<ExperienceDto> Experience { get; set; } = new();
+        public List<ProjectDto> Projects { get; set; } = new();
+        public List<string> Skills { get; set; } = new();
+        public List<LanguageDto> Languages { get; set; } = new();
         public string? PictureUrl { get; set; }
         public string CvUrl { get; set; } = string.Empty;
         public string? GithubUrl { get; set; }

--- a/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/CreateCandidate/CreateCandidateProfileCommand.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/CreateCandidate/CreateCandidateProfileCommand.cs
@@ -9,17 +9,6 @@ namespace Profile.API.Features.CandidateProfiles.Commands.CreateCandidate
         public string FirstName { get; set; } = string.Empty;
         public string LastName { get; set; } = string.Empty;
         public string Email { get; set; } = string.Empty;
-        public string PhoneNumber { get; set; } = string.Empty;
-        public string Location { get; set; } = string.Empty;
-        public List<EducationDto> Education { get; set; } = new();
-        public List<ExperienceDto> Experience { get; set; } = new();
-        public List<ProjectDto> Projects { get; set; } = new();
-        public List<string> Skills { get; set; } = new();
-        public List<LanguageDto> Languages { get; set; } = new();
-        public string? PictureUrl { get; set; }
-        public string CvUrl { get; set; } = string.Empty;
-        public string? GithubUrl { get; set; }
-        public string? GitlabUrl { get; set; }
-        public string? LinkedInUrl { get; set; }
+        public string? PhoneNumber { get; set; }
     }
 }

--- a/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/UpdateCandidate/UpdateCandidateProfileCommand.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/UpdateCandidate/UpdateCandidateProfileCommand.cs
@@ -1,4 +1,5 @@
 ﻿using MediatR;
+using Profile.API.DTOs;
 
 namespace Profile.API.Features.CandidateProfiles.Commands.UpdateCandidate
 {
@@ -11,11 +12,11 @@ namespace Profile.API.Features.CandidateProfiles.Commands.UpdateCandidate
         public string Email { get; set; } = string.Empty;
         public string PhoneNumber { get; set; } = string.Empty;
         public string Location { get; set; } = string.Empty;
-        public string Education { get; set; } = string.Empty;
-        public string Experience { get; set; } = string.Empty;
-        public string Projects { get; set; } = string.Empty;
-        public string Skills { get; set; } = string.Empty;
-        public string Languages { get; set; } = string.Empty;
+        public List<EducationDto> Education { get; set; } = new();
+        public List<ExperienceDto> Experience { get; set; } = new();
+        public List<ProjectDto> Projects { get; set; } = new();
+        public List<string> Skills { get; set; } = new();
+        public List<LanguageDto> Languages { get; set; } = new();
         public string? PictureUrl { get; set; }
         public string CvUrl { get; set; } = string.Empty;
         public string? GithubUrl { get; set; }

--- a/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/UpdateCandidate/UpdateCandidateProfileCommandHandler.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/UpdateCandidate/UpdateCandidateProfileCommandHandler.cs
@@ -9,7 +9,12 @@ namespace Profile.API.Features.CandidateProfiles.Commands.UpdateCandidate
     {
         public async Task<bool> Handle(UpdateCandidateProfileCommand request, CancellationToken cancellationToken)
         {
-            var entity = await context.CandidateProfiles.FirstOrDefaultAsync(p => p.Id == request.Id && p.UserId == request.UserId, cancellationToken);
+            var entity = await context.CandidateProfiles
+                .Include(p => p.Education)
+                .Include(p => p.Experience)
+                .Include(p => p.Projects)
+                .Include(p => p.Languages)
+                .FirstOrDefaultAsync(p => p.Id == request.Id && p.UserId == request.UserId, cancellationToken);
 
             if(entity == null)
             {

--- a/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/Validators/EducationDtoValidator.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/Validators/EducationDtoValidator.cs
@@ -1,0 +1,24 @@
+﻿using FluentValidation;
+using Profile.API.DTOs;
+
+namespace Profile.API.Features.CandidateProfiles.Commands.Validators
+{
+    public class EducationDtoValidator : AbstractValidator<EducationDto>
+    {
+        public EducationDtoValidator()
+        {
+            RuleFor(e => e.InstitutionName).NotEmpty().WithMessage("Institution name is required.")
+                .MaximumLength(50).WithMessage("Institution name cannot exceed 50 characters.");
+
+            RuleFor(e => e.Degree).MaximumLength(20).WithMessage("Degree cannot exceed 20 characters.");
+
+            RuleFor(e => e.StartDate)
+                .NotEmpty().WithMessage("Start date is required.")
+                .LessThanOrEqualTo(DateTime.Now).WithMessage("Start date must be a valid date.");
+
+            RuleFor(e => e.EndDate)
+                .LessThanOrEqualTo(DateTime.Now).WithMessage("Start date must be a valid date.")
+                .GreaterThan(e => e.StartDate).When(e => e.EndDate.HasValue).WithMessage("End date must be greater than Start date");
+        }
+    }
+}

--- a/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/Validators/ExperienceDtoValidator.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/Validators/ExperienceDtoValidator.cs
@@ -1,0 +1,25 @@
+﻿using FluentValidation;
+using Profile.API.DTOs;
+
+namespace Profile.API.Features.CandidateProfiles.Commands.Validators
+{
+    public class ExperienceDtoValidator : AbstractValidator<ExperienceDto>
+    {
+        public ExperienceDtoValidator()
+        {
+            RuleFor(e => e.CompanyName).NotEmpty().WithMessage("Company name is required.")
+                .MaximumLength(50).WithMessage("Company name cannot exceed 50 characters.");
+
+            RuleFor(e => e.Position).NotEmpty().WithMessage("Position is required.")
+                .MaximumLength(30).WithMessage("Position cannot exceed 30 characters.");
+
+            RuleFor(e => e.StartDate)
+                .NotEmpty().WithMessage("Start date is required.")
+                .LessThanOrEqualTo(DateTime.Now).WithMessage("Start date must be a valid date.");
+
+            RuleFor(e => e.EndDate)
+                .LessThanOrEqualTo(DateTime.Now).WithMessage("Start date must be a valid date.")
+                .GreaterThan(e => e.StartDate).When(e => e.EndDate.HasValue).WithMessage("End date must be greater than Start date");
+        }
+    }
+}

--- a/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/Validators/LanguageDtoValidator.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/Validators/LanguageDtoValidator.cs
@@ -1,0 +1,16 @@
+﻿using FluentValidation;
+using Profile.API.DTOs;
+
+namespace Profile.API.Features.CandidateProfiles.Commands.Validators
+{
+    public class LanguageDtoValidator : AbstractValidator<LanguageDto>
+    {
+        public LanguageDtoValidator()
+        {
+            RuleFor(l => l.Name).NotEmpty().WithMessage("Language name is required.")
+                .MaximumLength(30).WithMessage("Language name cannot exceed 30 characters.");
+
+            RuleFor(l => l.Level).MaximumLength(15).WithMessage("Level cannot exceed 15 characters.");
+        }
+    }
+}

--- a/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/Validators/ProjectDtoValidator.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/Validators/ProjectDtoValidator.cs
@@ -1,0 +1,19 @@
+﻿using FluentValidation;
+using Profile.API.DTOs;
+using Profile.API.Extensions;
+
+namespace Profile.API.Features.CandidateProfiles.Commands.Validators
+{
+    public class ProjectDtoValidator : AbstractValidator<ProjectDto>
+    {
+        public ProjectDtoValidator()
+        {
+            RuleFor(p => p.Name).NotEmpty().WithMessage("Project name is required.")
+                .MaximumLength(30).WithMessage("Project name cannot exceed 30 characters.");
+
+            RuleFor(p => p.Description).MaximumLength(250).WithMessage("Description cannot exceed 250 characters.");
+
+            RuleFor(p => p.RepositoryUrl).ValidUrl().WithName("RepositoryUrl");
+        }
+    }
+}

--- a/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/Validators/UpdateCandidateProfileCommandValidator.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Commands/Validators/UpdateCandidateProfileCommandValidator.cs
@@ -34,6 +34,13 @@ namespace Profile.API.Features.CandidateProfiles.Commands.Validators
             RuleFor(p => p.CvUrl).ValidUrl().WithName("CvUrl");
 
             RuleFor(p => p.PictureUrl).ValidUrl().WithName("PictureUrl");
+
+            RuleForEach(p => p.Skills).MaximumLength(20).WithMessage("Skill cannot exceed 20 characters.");
+
+            RuleForEach(p => p.Education).SetValidator(new EducationDtoValidator());
+            RuleForEach(p => p.Experience).SetValidator(new ExperienceDtoValidator());
+            RuleForEach(p => p.Projects).SetValidator(new ProjectDtoValidator());
+            RuleForEach(p => p.Languages).SetValidator(new LanguageDtoValidator());
         }
     }
 }

--- a/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Queries/GetCandidateProfile/GetCandidateProfileQueryHandler.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CandidateProfiles/Queries/GetCandidateProfile/GetCandidateProfileQueryHandler.cs
@@ -10,7 +10,12 @@ namespace Profile.API.Features.CandidateProfiles.Queries.GetCandidateProfile
     {
         public async Task<CandidateProfileDto?> Handle(GetCandidateProfileQuery request, CancellationToken cancellationToken)
         {
-            var profile = await context.CandidateProfiles.FirstOrDefaultAsync(p => p.UserId == request.UserId, cancellationToken);
+            var profile = await context.CandidateProfiles
+                .Include(p => p.Education)
+                .Include(p => p.Experience)
+                .Include(p => p.Projects)
+                .Include(p => p.Languages)
+                .FirstOrDefaultAsync(p => p.UserId == request.UserId, cancellationToken);
 
             if(profile == null)
             {

--- a/src/Services/ProfileService/Profile.API/Features/CompanyProfiles/Commands/CreateCompany/CreateCompanyProfileCommand.cs
+++ b/src/Services/ProfileService/Profile.API/Features/CompanyProfiles/Commands/CreateCompany/CreateCompanyProfileCommand.cs
@@ -6,12 +6,7 @@ namespace Profile.API.Features.CompanyProfiles.Commands.CreateCompany
     {
         public string UserId { get; set; } = string.Empty;
         public string CompanyName { get; set; } = string.Empty;
-        public string Description { get; set; } = string.Empty;
-        public string Location { get; set; } = string.Empty;
         public string ContactEmail { get; set; } = string.Empty;
-        public string ContactPhone { get; set; } = string.Empty;
-        public string? WebsiteUrl { get; set; }
-        public string? LinkedInUrl { get; set; }
-        public string? LogoUrl { get; set; }
+        public string? ContactPhone { get; set; } = string.Empty;
     }
 }

--- a/src/Services/ProfileService/Profile.API/Mapping/CandidateMappingProfile.cs
+++ b/src/Services/ProfileService/Profile.API/Mapping/CandidateMappingProfile.cs
@@ -9,7 +9,11 @@ namespace Profile.API.Mapping
     {
         public CandidateMappingProfile()
         {
-            CreateMap<CandidateProfile, CandidateProfileDto>();
+            CreateMap<CandidateProfile, CandidateProfileDto>().ReverseMap();
+            CreateMap<Education, EducationDto>().ReverseMap();
+            CreateMap<Experience, ExperienceDto>().ReverseMap();
+            CreateMap<Project, ProjectDto>().ReverseMap();
+            CreateMap<Language, LanguageDto>().ReverseMap();
 
             CreateMap<CreateCandidateProfileCommand, CandidateProfile>()
                 .ForMember(dest => dest.Id, opt => opt.Ignore())

--- a/src/Services/ProfileService/Profile.API/Migrations/20260426114536_AddNewCandidateProfileCollections.Designer.cs
+++ b/src/Services/ProfileService/Profile.API/Migrations/20260426114536_AddNewCandidateProfileCollections.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Profile.API.Data;
@@ -12,9 +13,11 @@ using Profile.API.Data;
 namespace Profile.API.Migrations
 {
     [DbContext(typeof(ProfileContext))]
-    partial class ProfileContextModelSnapshot : ModelSnapshot
+    [Migration("20260426114536_AddNewCandidateProfileCollections")]
+    partial class AddNewCandidateProfileCollections
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Services/ProfileService/Profile.API/Migrations/20260426114536_AddNewCandidateProfileCollections.cs
+++ b/src/Services/ProfileService/Profile.API/Migrations/20260426114536_AddNewCandidateProfileCollections.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Profile.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNewCandidateProfileCollections : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Education",
+                table: "CandidateProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "Experience",
+                table: "CandidateProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "Languages",
+                table: "CandidateProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "Projects",
+                table: "CandidateProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "Skills",
+                table: "CandidateProfiles");
+
+            migrationBuilder.AddColumn<List<string>>(
+                name: "Skills",
+                table: "CandidateProfiles",
+                type: "text[]",
+                nullable: false,
+                defaultValue: new List<string>());
+
+            migrationBuilder.CreateTable(
+                name: "Education",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    InstitutionName = table.Column<string>(type: "text", nullable: false),
+                    StartDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    EndDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Degree = table.Column<string>(type: "text", nullable: false),
+                    CandidateProfileId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Education", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Education_CandidateProfiles_CandidateProfileId",
+                        column: x => x.CandidateProfileId,
+                        principalTable: "CandidateProfiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Experience",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CompanyName = table.Column<string>(type: "text", nullable: false),
+                    Position = table.Column<string>(type: "text", nullable: false),
+                    StartDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    EndDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CandidateProfileId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Experience", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Experience_CandidateProfiles_CandidateProfileId",
+                        column: x => x.CandidateProfileId,
+                        principalTable: "CandidateProfiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Languages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    Level = table.Column<string>(type: "text", nullable: true),
+                    CandidateProfileId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Languages", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Languages_CandidateProfiles_CandidateProfileId",
+                        column: x => x.CandidateProfileId,
+                        principalTable: "CandidateProfiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Projects",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: false),
+                    RepositoryLink = table.Column<string>(type: "text", nullable: true),
+                    CandidateProfileId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Projects", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Projects_CandidateProfiles_CandidateProfileId",
+                        column: x => x.CandidateProfileId,
+                        principalTable: "CandidateProfiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Education_CandidateProfileId",
+                table: "Education",
+                column: "CandidateProfileId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Experience_CandidateProfileId",
+                table: "Experience",
+                column: "CandidateProfileId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Languages_CandidateProfileId",
+                table: "Languages",
+                column: "CandidateProfileId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_CandidateProfileId",
+                table: "Projects",
+                column: "CandidateProfileId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Education");
+
+            migrationBuilder.DropTable(
+                name: "Experience");
+
+            migrationBuilder.DropTable(
+                name: "Languages");
+
+            migrationBuilder.DropTable(
+                name: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "Skills",
+                table: "CandidateProfiles");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Skills",
+                table: "CandidateProfiles",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Education",
+                table: "CandidateProfiles",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Experience",
+                table: "CandidateProfiles",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Languages",
+                table: "CandidateProfiles",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Projects",
+                table: "CandidateProfiles",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}


### PR DESCRIPTION
This PR changes `CandidateProfile` entity so it contains new collections:
- `Education`
- `Experience`
- `Projects`
- `Languages`

Attribute `Skills` was also changed from string to a list of strings. Entities, commands, handlers, DTOs and validators were updated. New database migration was created.

Closes #34 