### PR TITLE
Catalog service: CRUD, search and filter for job ads

### DIFF
--- a/src/Services/Catalog/Controllers/CatalogController.cs
+++ b/src/Services/Catalog/Controllers/CatalogController.cs
@@ -1,6 +1,119 @@
+using Catalog.Entities;
+using Catalog.Repositories;
+using Microsoft.AspNetCore.Mvc;
+
 namespace Catalog.Controllers;
 
-public class CatalogController
+[ApiController]
+[Route("api/v1/[controller]")]
+public class CatalogController : ControllerBase
 {
+    private readonly IJobRepository _repository;
+    public CatalogController(IJobRepository repository)
+    {
+        _repository = repository;
+    }
+    
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<Job>>> GetAllJobs()
+    {
+        var jobs = await _repository.GetAllAsync();
+        
+        return Ok(jobs);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<Job>> GetById(string id)
+    {
+        var job = await _repository.GetByIdAsync(id);
+        if (job == null)
+        {
+            return NotFound();
+        }
+        return Ok(job);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(Job),StatusCodes.Status201Created)]
+    public async Task<ActionResult<Job>> CreateJob([FromBody] Job job)
+    {
+        await _repository.CreateJobAsync(job);
+        return CreatedAtAction(nameof(GetById), new { id = job.Id }, job);
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(typeof(Job), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<Job>> UpdateJob(string id, [FromBody] Job job)
+    {
+        if (id != job.Id)
+            return BadRequest("Route id does not match job id in body.");
+
+        var result = await _repository.UpdateJobAsync(job);
+        if (!result)
+            return NotFound();
+        return Ok(job);
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> DeleteJob(string id)
+    {
+        var result = await _repository.DeleteJobAsync(id);
+        if (!result)
+            return NotFound(null);
+        return Ok();
+    }
+    
+    [HttpGet("search")]
+    public async Task<ActionResult<IEnumerable<Job>>> SearchJob([FromQuery] string query)
+    {
+        var jobs = await _repository.SearchJobAsync(query);
+        return Ok(jobs);
+    }
+    
+    [HttpGet("filter")]
+    public async Task<ActionResult<IEnumerable<Job>>> FilterJob(
+        [FromQuery] JobType? jobType,
+        [FromQuery] ExperienceLevel? experienceLevel,
+        [FromQuery] WorkMode? workMode,[FromQuery] string? city)   
+    {
+        var jobs = await _repository.FilterJobAsync(jobType, experienceLevel, workMode, city);
+        return Ok(jobs);
+    }
+
+    [HttpGet("active")]
+    public async Task<ActionResult<IEnumerable<Job>>> GetActiveJobs()
+    {
+        var jobs = await _repository.GetActiveJobsAsync();
+        return Ok(jobs);
+    }
+    
+    
+    [HttpGet("filter/salary")]
+    public async Task<ActionResult<IEnumerable<Job>>> FilterBySalary(
+        [FromQuery] decimal? minSalary,
+        [FromQuery] decimal? maxSalary)
+    {
+        var jobs = await _repository.FilterBySalaryAsync(minSalary, maxSalary);
+        return Ok(jobs);
+    }
+    
+    [HttpGet("company/{companyId}")]
+    public async Task<ActionResult<IEnumerable<Job>>> GetByCompanyId(string companyId)
+    {
+        var jobs = await _repository.GetByCompanyIdAsync(companyId);
+        return Ok(jobs);
+    }
+    
+    
+    [HttpGet("sorted/salary")]
+    public async Task<ActionResult<IEnumerable<Job>>> GetSortedBySalary([FromQuery] bool ascending = true)
+    {
+        var jobs = await _repository.GetSortedBySalaryAsync(ascending);
+        return Ok(jobs);
+    }
     
 }

--- a/src/Services/Catalog/Data/ICatalogContext.cs
+++ b/src/Services/Catalog/Data/ICatalogContext.cs
@@ -3,7 +3,7 @@ using MongoDB.Driver;
 
 namespace Catalog.Data;
 
-public class ICatalogContext
+public interface ICatalogContext
 {
     IMongoCollection<Job> Jobs { get; }   
 }

--- a/src/Services/Catalog/Program.cs
+++ b/src/Services/Catalog/Program.cs
@@ -11,6 +11,13 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 
 
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowFrontend", policy => policy.WithOrigins("http://localhost:4200")
+        .AllowAnyHeader()
+        .AllowAnyMethod());
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -20,6 +27,8 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+app.UseCors("AllowFrontend");
 
 app.MapControllers();
 

--- a/src/Services/Catalog/Program.cs
+++ b/src/Services/Catalog/Program.cs
@@ -1,5 +1,6 @@
 using Catalog.Data;
 using Catalog.Repositories;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -7,7 +8,11 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddSwaggerGen();
 builder.Services.AddSingleton<ICatalogContext, CatalogContext>();
 builder.Services.AddScoped<IJobRepository,JobRepository>();
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 
 

--- a/src/Services/Catalog/Program.cs
+++ b/src/Services/Catalog/Program.cs
@@ -1,10 +1,12 @@
 using Catalog.Data;
+using Catalog.Repositories;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddSwaggerGen();
-builder.Services.AddScoped<ICatalogContext, CatalogContext>();
+builder.Services.AddSingleton<ICatalogContext, CatalogContext>();
+builder.Services.AddScoped<IJobRepository,JobRepository>();
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 

--- a/src/Services/Catalog/Repositories/IJobRepository.cs
+++ b/src/Services/Catalog/Repositories/IJobRepository.cs
@@ -1,6 +1,29 @@
+using Catalog.Entities;
+
 namespace Catalog.Repositories;
 
-public class IJobRepository
+public interface IJobRepository
 {
+    Task<IEnumerable<Job>> GetAllAsync();
+    
+    Task<Job?> GetByIdAsync(string id);
+    
+    Task CreateJobAsync(Job job);
+    
+    Task<bool> UpdateJobAsync(Job job);
+    
+    Task<bool> DeleteJobAsync(string id);
+    
+    Task<IEnumerable<Job>> SearchJobAsync(string query);
+    
+    Task<IEnumerable<Job>> FilterJobAsync(JobType? jobType , ExperienceLevel? experienceLevel , WorkMode? workMode, string? city);
+    
+    Task<IEnumerable<Job>> GetActiveJobsAsync();
+    
+    Task<IEnumerable<Job>> FilterBySalaryAsync(decimal? minSalary, decimal? maxSalary);
+    
+    Task<IEnumerable<Job>> GetByCompanyIdAsync(string companyId);
+    
+    Task<IEnumerable<Job>> GetSortedBySalaryAsync(bool ascending = true);
     
 }

--- a/src/Services/Catalog/Repositories/JobRepository.cs
+++ b/src/Services/Catalog/Repositories/JobRepository.cs
@@ -1,6 +1,166 @@
+using Catalog.Data;
+using Catalog.Entities;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
 namespace Catalog.Repositories;
 
-public class JobRepository
+public class JobRepository : IJobRepository
 {
+    private readonly ICatalogContext _context;
+    public JobRepository(ICatalogContext catalogContext)
+    {
+        _context = catalogContext ??  throw new ArgumentNullException(nameof(catalogContext));
+    }
+
+    public async Task<IEnumerable<Job>> GetAllAsync()
+    {
+        return await _context.Jobs.Find(j => true).ToListAsync();
+    }
+
+    public async Task<Job?> GetByIdAsync(string id)
+    {
+        return await _context.Jobs.Find(j => j.Id == id).FirstOrDefaultAsync();
+    }
+
+    public async Task CreateJobAsync(Job job)
+    { 
+        await _context.Jobs.InsertOneAsync(job);
+    }
+
+    public async Task<bool> UpdateJobAsync(Job job)
+    {
+        var updateJob = await _context.Jobs.ReplaceOneAsync(j => j.Id == job.Id, job);
+        return updateJob.ModifiedCount > 0;
+    }
+
+    public async Task<bool> DeleteJobAsync(string id)
+    {
+        var deleteJob = await _context.Jobs.DeleteOneAsync(j => j.Id == id);
+        return deleteJob.DeletedCount > 0;
+    }
     
+    public async Task<IEnumerable<Job>> SearchJobAsync(string query)
+    { 
+        var filter =
+            Builders<Job>.Filter.Or(
+                Builders<Job>.Filter.Regex(
+                    j => j.Title,
+                    new MongoDB.Bson.BsonRegularExpression(query, "i")
+                ),
+
+                Builders<Job>.Filter.Regex(
+                    j => j.Description,
+                    new MongoDB.Bson.BsonRegularExpression(query, "i")
+                ),
+
+                Builders<Job>.Filter.Regex(
+                    j => j.CompanyName,
+                    new MongoDB.Bson.BsonRegularExpression(query, "i")
+                )
+            );
+
+        return await _context
+            .Jobs
+            .Find(filter)
+            .ToListAsync();
+    }
+
+
+    public async Task<IEnumerable<Job>> FilterJobAsync(JobType? jobType, ExperienceLevel? experienceLevel,
+            WorkMode? workMode, string? city)
+    {
+        var filterBuilder = Builders<Job>.Filter;
+        var filters = new List<FilterDefinition<Job>>();
+        
+        if (jobType.HasValue)
+        {
+            filters.Add(
+                filterBuilder.Eq(j => j.JobType, jobType.Value)
+            );
+        }
+
+        if (experienceLevel.HasValue)
+        {
+            filters.Add(
+                filterBuilder.Eq(
+                    j => j.ExperienceLevel,
+                    experienceLevel.Value
+                )
+            );
+        }
+
+        if (workMode.HasValue)
+        {
+            filters.Add(
+                filterBuilder.Eq(
+                    j => j.WorkMode,
+                    workMode.Value
+                )
+            );
+        }
+
+        if (!string.IsNullOrWhiteSpace(city))
+        {
+            filters.Add(
+                filterBuilder.Regex(
+                    j => j.City, new BsonRegularExpression($"^{city}$", "i")
+                    )
+                );
+        }
+
+        var finalFilter = filters.Count > 0
+            ? filterBuilder.And(filters)
+            : filterBuilder.Empty;
+
+        return await _context
+            .Jobs
+            .Find(finalFilter)
+            .ToListAsync();
+    }
+    
+     
+    public async Task<IEnumerable<Job>> GetActiveJobsAsync()
+    { 
+        return await _context.Jobs.Find(j => j.IsActive).ToListAsync();
+    }
+        
+     
+    public async Task<IEnumerable<Job>> FilterBySalaryAsync(decimal? minSalary, decimal? maxSalary)
+    {
+        var filterBuilder = Builders<Job>.Filter;
+        var filters = new List<FilterDefinition<Job>>();
+
+        if (minSalary.HasValue)
+        {
+            filters.Add(filterBuilder.Gte(j => j.SalaryMax, minSalary.Value));
+        }
+
+        if (maxSalary.HasValue)
+        {
+            filters.Add(filterBuilder.Lte(j => j.SalaryMin, maxSalary.Value));
+        }
+
+        var finalFilter = filters.Count > 0
+            ? filterBuilder.And(filters)
+            : filterBuilder.Empty;
+
+        return await _context.Jobs.Find(finalFilter).ToListAsync();
+    }
+    
+    
+    public async Task<IEnumerable<Job>> GetByCompanyIdAsync(string companyId)
+    { 
+        return await _context.Jobs.Find(j => j.CompanyId == companyId).ToListAsync();
+    }
+    
+    
+    public async Task<IEnumerable<Job>> GetSortedBySalaryAsync(bool ascending = true)
+    { 
+        var sort = ascending 
+            ? Builders<Job>.Sort.Ascending(j => j.SalaryMin) 
+            : Builders<Job>.Sort.Descending(j => j.SalaryMin);
+        
+        return await _context.Jobs.Find(j => true).Sort(sort).ToListAsync();
+    }
 }


### PR DESCRIPTION
Backend part for Sprint 2

Implemented CRUD operations, search, and filtering for job ads.

- CRUD endpoints (create, read, update, delete)
- Search and filtering (by job type, experience level, location, salary, company)
- CORS configured for Angular

Closes #37
Closes #38
Closes #39